### PR TITLE
Add requirements.txt and document usage with Google's two-factor authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # EZPortify
 
-Transfer all of your spotify playlists to google play.
+Transfer all of your Spotify-playlists to Google Play Music.
 Also spits out all playlists and their tracks to a text file.
 
 ### Preface
 
-Feel free to check out my new version that runs directly in your browser. No need to download anything or give anyone your password! --> **[Portify.JS](https://github.com/jordam/portify.js/)**
+Feel free to check out my new version that runs directly in your browser. No need to download anything or give anyone your password! See **[Portify.JS](https://github.com/jordam/portify.js/)**
 
 ### Instructions
 
+1. Run `pip install -r requirements.txt` to install dependencies.
+2. Run `python ezportify.py` to run the script. It will prompt you for your Google username and password, and a Spotify Ouath Token, which you can get through [Spotify developer pages]( https://developer.spotify.com/web-api/console/get-current-user-playlists/).
 
-Run ezportify.py with python and follow the instructions in the command prompt. You will need your google play username and password along with a spotify oauth token from https://developer.spotify.com/web-api/console/get-current-user-playlists/
-
-If you are unable to sign in to your Google account, turn on access for less secure apps here: https://www.google.com/settings/security/lesssecureapps/  
-You may turn it off after the program has completed.
+__Notes:__
+* If you are unable to sign in to your Google account, turn on access for less secure apps here: https://www.google.com/settings/security/lesssecureapps/  - You may turn it off after the program has completed.
+* If you have two-factor authentication activated, you'll need a app password. You can create that [here](https://security.google.com/settings/security/apppasswords), and read more about it on [Googles help pages](https://support.google.com/accounts/answer/185833)
 
 Run ezportify.py -h for help (ezportify.exe -h for windows users)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+certifi
+gpsoauth


### PR DESCRIPTION
Adds a `requirements.txt`-file to make it easier to run.

Also adds the following Information to the README:
- Explicitly state setup process
- How to get it running if you're using two-factor authentication with Google.
